### PR TITLE
Print an error and exit if input cannot be parsed

### DIFF
--- a/lib/pups/config.rb
+++ b/lib/pups/config.rb
@@ -9,7 +9,7 @@ class Pups::Config
       STDERR.puts "Failed to parse #{config_file}"
       STDERR.puts "This is probably a formatting error in #{config_file}"
       STDERR.puts "Cannot continue. Edit #{config_file} and try again."
-      exit
+      raise
     end
   end
 

--- a/lib/pups/config.rb
+++ b/lib/pups/config.rb
@@ -3,7 +3,14 @@ class Pups::Config
   attr_reader :config, :params
 
   def self.load_file(config_file)
-    new YAML.load_file(config_file)
+    begin
+      new YAML.load_file(config_file)
+    rescue Exception
+      STDERR.puts "Failed to parse #{config_file}"
+      STDERR.puts "This is probably a formatting error in #{config_file}"
+      STDERR.puts "Cannot continue. Edit #{config_file} and try again."
+      exit
+    end
   end
 
   def self.load_config(config)


### PR DESCRIPTION
Errors like "mapping values are not allowed in this context at line 2 column 7 (Psych::SyntaxError)" don't make sense to normal people. I added an error message if the input file can't be parsed.